### PR TITLE
fix(Proxy): remove unneeded fallback function

### DIFF
--- a/src/Proxy.sol
+++ b/src/Proxy.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v4.6.0) (proxy/Proxy.sol)
 
-pragma solidity 0.8.19;
+pragma solidity ^0.8.19;
 
 /**
  * @dev This abstract contract provides a fallback function that delegates all calls to another contract using the EVM
@@ -65,14 +65,6 @@ abstract contract Proxy {
      * function in the contract matches the call data.
      */
     fallback() external payable virtual {
-        _fallback();
-    }
-
-    /**
-     * @dev Fallback function that delegates calls to the address returned by `_implementation()`. Will run if call data
-     * is empty.
-     */
-    receive() external payable virtual {
         _fallback();
     }
 


### PR DESCRIPTION
https://forum.openzeppelin.com/t/proxy-sol-fallback/36951/8


The fallback alone would indeed be enough.

 Fallback is not limited to` msg.value == 0` (if its marked `payable`). Both functions can support value.

The difference between receive and fallback is in the msg.data. If the calldata is empty and if there is a receive function, it fill be used. Otherwise, fallback is used. This means that regardless of the value, fallback will be called if there is some data. `fallback` is also the one that is called if there is no data, but receive is not defined.

So why do we have a receive function that is not really needed? To silent solidity warnings that sometimes happen when you have a fallback function but no receive function.
- @amxx 

see <https://github.com/OpenZeppelin/openzeppelin-contracts/pull/4434#user-content-fn-1-d80326bcc66636a621980cca7d5a8b3a>